### PR TITLE
Don't invoke `JSON.stringify()` when the request body is a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function setupZeitFetch(fetch) {
 		opts.headers.set('host', opts.headers.get('host') || parseUrl(url).host);
 
 		// Convert Object bodies to JSON
-		if (opts.body && typeof opts.body === 'object') {
+		if (opts.body && typeof opts.body === 'object' && !Buffer.isBuffer(opts.body)) {
 			opts.body = JSON.stringify(opts.body);
 			opts.headers.set('Content-Type', 'application/json');
 			opts.headers.set('Content-Length', Buffer.byteLength(opts.body));

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^4.10.0",
     "lint-staged": "^7.0.0",
     "node-fetch": "2.1.2",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "raw-body": "^2.3.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,10 @@
+const assert = require('assert');
+const toBuffer = require('raw-body');
+const listen = require('async-listen');
 const {createServer} = require('http');
 const fetch = require('../index')();
 
-exports.retriesUponHttp500 = () => {
+exports.retriesUponHttp500 = async () => {
 	let i = 0;
 	const server = createServer((req, res) => {
 		if (i++ < 2) {
@@ -11,34 +14,18 @@ exports.retriesUponHttp500 = () => {
 			res.end('ha');
 		}
 	});
+	await listen(server);
+	const {port} = server.address();
 
-	return new Promise((resolve, reject) => {
-		server.listen(async () => {
-			const {port} = server.address();
-			try {
-				const res = await fetch(`http://127.0.0.1:${port}`);
-				const resBody = await res.text();
-				server.close();
-				if (resBody === 'ha') {
-					resolve();
-				} else {
-					reject(resBody);
-				}
-			} catch (err) {
-				reject(err);
-			}
-		});
-		server.on('error', reject);
-	});
+	const res = await fetch(`http://127.0.0.1:${port}`);
+	const resBody = await res.text();
+	server.close();
+	assert.equal(resBody, 'ha');
 };
 
 exports.worksWithHttps = async () => {
 	const res = await fetch('https://zeit.co');
-	const resText = await res.text();
-
-	if (!resText.includes('Now')) {
-		throw new Error("Doesn't work with https");
-	}
+	assert.equal(res.headers.get('Server'), 'now');
 };
 
 /**
@@ -46,4 +33,26 @@ exports.worksWithHttps = async () => {
  * as a test to make sure that we switch the agent when the it
  * happens
  */
-exports.switchesAgentsOnRedirect = async () => fetch(`http://zeit.co`);
+exports.switchesAgentsOnRedirect = async () => {
+	const res = await fetch('http://zeit.co');
+	assert.equal(res.url, 'https://zeit.co/');
+};
+
+exports.supportsBufferRequestBody = async () => {
+	const server = createServer(async (req, res) => {
+		const body = await toBuffer(req);
+		assert(Buffer.isBuffer(body));
+		assert.equal(body.toString(), 'foo');
+		res.end(JSON.stringify({body: body.toString()}));
+	});
+	await listen(server);
+	const {port} = server.address();
+
+	const res = await fetch(`http://127.0.0.1:${port}`, {
+		method: 'POST',
+		body: Buffer.from('foo')
+	});
+	const body = await res.json();
+	server.close();
+	assert.deepEqual(body, {body: 'foo'});
+};


### PR DESCRIPTION
There's probably other types that we should blacklist here, but
this will fix the `now-create` file upload bug in the instant endpoint
for now.

Test case included (and also refactored the existing tests a bit).