### PR TITLE
add fix for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function setup(fetch) {
 		fetch = require('node-fetch');
 	}
 
-	fetch = fetch.default || fetch
+	fetch = fetch.default || fetch;
 
 	if (typeof fetch !== 'function') {
 		throw new Error(


### PR DESCRIPTION
Webpack seems to strip a function from an export if it has other properties (like in node-fetch) which makes it so `@zeit/fetch` isn't compatible with `webpack`.

This hack fixes that