### PR TITLE
Change TypeScript import to match module definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as https from 'http';
 import { Options as RetryOptions } from 'async-retry';
-import { Request, RequestInit, Response } from 'node-fetch';
+import { Headers, Request, RequestInit, Response } from 'node-fetch';
 
 export type FetchOptions = RequestInit & {
 	agent?: https.Agent | http.Agent
@@ -13,5 +13,14 @@ export type Fetch = (
 	options?: FetchOptions
 ) => Promise<Response>;
 
-export default function SetupFetch(client?: Fetch, agentOptions?: http.AgentOptions | https.AgentOptions): Fetch;
+export type FetchModule = {
+	default: Fetch;
+	Headers: Headers;
+}
+
+export default function SetupFetch(
+	fetchModule?: FetchModule,
+	agentOptions?: http.AgentOptions | https.AgentOptions
+): Fetch;
+
 export * from 'node-fetch';

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export type Fetch = (
 
 export type FetchModule = {
 	default: Fetch;
-	Headers: Headers;
+	Headers: typeof Headers;
 }
 
 export default function SetupFetch(

--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,18 @@ if not provided, with the following settings:
 
 ## How to use
 
+JavaScript
+
 ```js
 const fetch = require('@zeit/fetch')(require('some-fetch-implementation'))
+```
+
+TypeScript
+
+```typescript
+import createFetch from "@zeit/fetch"
+import * as fetch from "some-fetch-implementation";
+const fetch = createFetch(fetch);
 ```
 
 If no fetch implementation is supplied, it will attempt to use peerDep `node-fetch`.


### PR DESCRIPTION
I noticed that the example in vanilla JS does not translate properly to TypeScript because the first argument `client` is actually expected to be the fetch module, rather than the fetch default export. This changes the type definitions to match how the module should be consumed.