### PR TITLE
Add support for URLSearchParams

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ const HttpAgent = require('agentkeepalive');
 const debug = require('debug')('@zeit/fetch');
 const setupFetchRetry = require('@zeit/fetch-retry');
 const setupFetchCachedDns = require('@zeit/fetch-cached-dns');
+const urlModule = require('url');
 
 const {HttpsAgent} = HttpAgent;
+const {URLSearchParams} = urlModule;
 
 const AGENT_OPTIONS = {
 	maxSockets: 200,
@@ -45,8 +47,13 @@ function setupZeitFetch(fetch, agentOpts = {}) {
 		// Workaround for node-fetch + agentkeepalive bug/issue
 		opts.headers.set('host', opts.headers.get('host') || parseUrl(url).host);
 
-		// Convert Object bodies to JSON
-		if (opts.body && typeof opts.body === 'object' && !Buffer.isBuffer(opts.body)) {
+		// Convert Object bodies to JSON if they are JS objects
+		if (
+			opts.body &&
+			!(opts.body instanceof URLSearchParams) &&
+			typeof opts.body === 'object' &&
+			!Buffer.isBuffer(opts.body)
+		) {
 			opts.body = JSON.stringify(opts.body);
 			opts.headers.set('Content-Type', 'application/json');
 			opts.headers.set('Content-Length', Buffer.byteLength(opts.body));


### PR DESCRIPTION
zeit/fetch doesn't work when passing a `URLSearchParams` object as the body. This is allowed by the spec, and supported in `node-fetch`.

Added a test for this, and for the current behavior of transforming bare objects to JSON.