### PR TITLE
Add `err.url` and `err.opts` properties when fetch throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function getAgent(url, agentOpts) {
 }
 
 function setupZeitFetch(fetch, agentOpts = {}) {
-	return function zeitFetch(url, opts = {}) {
+	return async function zeitFetch(url, opts = {}) {
 		if (!opts.agent) {
 			// Add default `agent` if none was provided
 			opts.agent = getAgent(url, {AGENT_OPTIONS, ...agentOpts});
@@ -57,8 +57,14 @@ function setupZeitFetch(fetch, agentOpts = {}) {
 			redirectOpts.agent = getAgent(res.headers.get('Location'));
 		};
 
-		debug('%s %s', opts.method || 'GET', url);
-		return fetch(url, opts);
+		try {
+			debug('%s %s', opts.method || 'GET', url);
+			return await fetch(url, opts);
+		} catch (err) {
+			err.url = url;
+			err.opts = opts;
+			throw err;
+		}
 	};
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,8 +24,8 @@ exports.retriesUponHttp500 = async () => {
 };
 
 exports.worksWithHttps = async () => {
-	const res = await fetch('https://zeit.co');
-	assert.equal(res.headers.get('Server'), 'now');
+	const res = await fetch('https://vercel.com');
+	assert.equal(res.headers.get('Server'), 'Vercel');
 };
 
 /**
@@ -34,8 +34,8 @@ exports.worksWithHttps = async () => {
  * happens
  */
 exports.switchesAgentsOnRedirect = async () => {
-	const res = await fetch('http://zeit.co');
-	assert.equal(res.url, 'https://zeit.co/');
+	const res = await fetch('http://vercel.com');
+	assert.equal(res.url, 'https://vercel.com/');
 };
 
 exports.supportsBufferRequestBody = async () => {
@@ -55,4 +55,18 @@ exports.supportsBufferRequestBody = async () => {
 	const body = await res.json();
 	server.close();
 	assert.deepEqual(body, {body: 'foo'});
+};
+
+exports.errorContext = async () => {
+	let err;
+	const url = `http://127.0.0.1/\u0019`;
+	try {
+		await fetch(url);
+	} catch (_err) {
+		err = _err;
+	}
+	assert(err);
+	assert.equal(err.code, 'ERR_UNESCAPED_CHARACTERS');
+	assert.equal(err.url, url);
+	assert.equal(err.opts.redirect, 'manual');
 };


### PR DESCRIPTION
Also fixes tests for Vercel rename.