### PR TITLE
fix: serialize only plain JS objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@ const HttpAgent = require('agentkeepalive');
 const debug = require('debug')('@vercel/fetch');
 const setupFetchRetry = require('@vercel/fetch-retry');
 const setupFetchCachedDns = require('@vercel/fetch-cached-dns');
-const urlModule = require('url');
+const isPlainObject = require('is-plain-obj');
 
 const {HttpsAgent} = HttpAgent;
-const {URLSearchParams} = urlModule;
 
 const AGENT_OPTIONS = {
 	maxSockets: 200,
@@ -52,13 +51,8 @@ function setupVercelFetch(fetch, agentOpts = {}) {
 			opts.headers.get('host') || parseUrl(url).host
 		);
 
-		// Convert Object bodies to JSON if they are JS objects
-		if (
-			opts.body &&
-			!(opts.body instanceof URLSearchParams) &&
-			typeof opts.body === 'object' &&
-			!Buffer.isBuffer(opts.body)
-		) {
+		// Convert Object bodies to JSON if they are plain JS objects
+		if (isPlainObject(opts.body)) {
 			opts.body = JSON.stringify(opts.body);
 			opts.headers.set('Content-Type', 'application/json');
 			opts.headers.set('Content-Length', Buffer.byteLength(opts.body));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@vercel/fetch-cached-dns": "^2.0.1",
     "@vercel/fetch-retry": "^5.0.2",
     "agentkeepalive": "3.4.1",
-    "debug": "3.1.0"
+    "debug": "3.1.0",
+    "is-plain-obj": "^3.0.0"
   },
   "peerDependencies": {
     "@types/node-fetch": "2",
@@ -46,7 +47,9 @@
     "@zeit/best": "0.5.2",
     "@zeit/eslint-config-node": "0.2.13",
     "async-listen": "1.0.0",
+    "busboy": "^0.3.1",
     "eslint": "5.14.1",
+    "form-data": "^4.0.0",
     "lint-staged": "8.1.4",
     "node-fetch": "2.6.1",
     "pre-commit": "1.2.2",

--- a/test/index.js
+++ b/test/index.js
@@ -126,7 +126,7 @@ exports.supportsFormDataRequestBody = async () => {
 			req.pipe(busboy);
 		});
 		assert.ok(!error);
-		assert.match(req.headers['content-type'], /multipart\/form-data;/);
+		assert.ok(/multipart\/form-data;/.test(req.headers['content-type']));
 		assert.deepEqual(body, {
 			fieldname: 'file',
 			filename: 'dummy.txt',
@@ -140,10 +140,18 @@ exports.supportsFormDataRequestBody = async () => {
 	const {port} = server.address();
 
 	const formData = new FormData();
-	formData.append('file', Readable.from(['input string']), {
-		filename: 'dummy.txt',
-		contentType: 'text/plain'
-	});
+	const readable = new Readable();
+	readable._read = () => {};
+	readable.push(Buffer.from('input string'));
+	readable.push(null);
+	formData.append(
+		'file',
+		readable,
+		{
+			filename: 'dummy.txt',
+			contentType: 'text/plain'
+		}
+	);
 
 	const res = await fetch(`http://127.0.0.1:${port}`, {
 		method: 'POST',

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,9 @@ const listen = require('async-listen');
 const {createServer} = require('http');
 const fetch = require('../index')();
 const url = require('url');
+const FormData = require('form-data');
+const Busboy = require('busboy');
+const {Readable} = require('stream');
 
 exports.retriesUponHttp500 = async () => {
 	let i = 0;
@@ -94,6 +97,57 @@ exports.supportsSearchParamsRequestBody = async () => {
 	const res = await fetch(`http://127.0.0.1:${port}`, {
 		method: 'POST',
 		body: new url.URLSearchParams({foo: 'bar'})
+	});
+	await res.text();
+	server.close();
+};
+
+exports.supportsFormDataRequestBody = async () => {
+	const server = createServer(async (req, res) => {
+		const [body, error] = await new Promise(resolve => {
+			const busboy = new Busboy({headers: req.headers});
+			busboy.on('error', err => resolve([null, err]));
+			busboy.on('file', async (fieldname, file, filename, encoding, mimetype) => {
+				let fileContent = '';
+				try {
+					for await (const chunk of file) {
+						fileContent += chunk;
+					}
+
+					resolve([{fieldname, filename, encoding, mimetype, fileContent}]);
+				} catch (error_) {
+					resolve([null, error_]);
+				}
+			});
+			busboy.on('finish', () => {
+				res.end();
+			});
+			setTimeout(() => resolve([null, new Error('Timeout')]), 3000);
+			req.pipe(busboy);
+		});
+		assert.ok(!error);
+		assert.match(req.headers['content-type'], /multipart\/form-data;/);
+		assert.deepEqual(body, {
+			fieldname: 'file',
+			filename: 'dummy.txt',
+			encoding: '7bit',
+			mimetype: 'text/plain',
+			fileContent: 'input string'
+		});
+		res.end();
+	});
+	await listen(server);
+	const {port} = server.address();
+
+	const formData = new FormData();
+	formData.append('file', Readable.from(['input string']), {
+		filename: 'dummy.txt',
+		contentType: 'text/plain'
+	});
+
+	const res = await fetch(`http://127.0.0.1:${port}`, {
+		method: 'POST',
+		body: formData
 	});
 	await res.text();
 	server.close();

--- a/test/index.js
+++ b/test/index.js
@@ -109,15 +109,15 @@ exports.supportsFormDataRequestBody = async () => {
 			busboy.on('error', err => resolve([null, err]));
 			busboy.on('file', async (fieldname, file, filename, encoding, mimetype) => {
 				let fileContent = '';
-				try {
-					for await (const chunk of file) {
-						fileContent += chunk;
-					}
-
+				file.on('data', chunk => {
+					fileContent += chunk;
+				});
+				file.on('end', () => {
 					resolve([{fieldname, filename, encoding, mimetype, fileContent}]);
-				} catch (error_) {
+				});
+				file.on('error', error_ => {
 					resolve([null, error_]);
-				}
+				});
 			});
 			busboy.on('finish', () => {
 				res.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,11 @@ async-retry@^1.3.1:
   dependencies:
     retry "0.12.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -343,6 +348,13 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+busboy@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.3.1.tgz#170899274c5bf38aae27d5c62b71268cd585fd1b"
+  integrity sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
+  dependencies:
+    dicer "0.3.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -481,6 +493,13 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^2.14.1, commander@^2.9.0:
   version "2.20.3"
@@ -629,10 +648,22 @@ del@^3.0.0:
     pify "^3.0.0"
     rimraf "^2.2.8"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
   integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
+
+dicer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
+  integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
+  dependencies:
+    streamsearch "0.1.2"
 
 diff@3.5.0:
   version "3.5.0"
@@ -938,6 +969,15 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -1323,6 +1363,11 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -1592,6 +1637,18 @@ micromatch@^3.1.10, micromatch@^3.1.8:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+mime-db@1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
+  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
+
+mime-types@^2.1.12:
+  version "2.1.29"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
+  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+  dependencies:
+    mime-db "1.46.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -2195,6 +2252,11 @@ static-extend@^0.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
zeit/fetch doesn't work with FormData as the body is being serialized and sent as json. We should be serializing only plain JS objects and allow others to be passed directly to node-fetch.

Added a test to check support for file uploads.

Also fixes [https://github.com/vercel/fetch/issues/33](https://github.com/vercel/fetch/issues/33)