### PR TITLE
Bump `@vercel/fetch-cached-dns` to `2.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/vercel/fetch#readme",
   "dependencies": {
     "@types/async-retry": "1.2.1",
-    "@vercel/fetch-cached-dns": "2.0.2",
+    "@vercel/fetch-cached-dns": "^2.0.2",
     "@vercel/fetch-retry": "^5.0.2",
     "agentkeepalive": "3.4.1",
     "debug": "3.1.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/vercel/fetch#readme",
   "dependencies": {
     "@types/async-retry": "1.2.1",
-    "@vercel/fetch-cached-dns": "^2.0.1",
+    "@vercel/fetch-cached-dns": "2.0.2",
     "@vercel/fetch-retry": "^5.0.2",
     "agentkeepalive": "3.4.1",
     "debug": "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,13 +91,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@vercel/fetch-cached-dns@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@vercel/fetch-cached-dns/-/fetch-cached-dns-2.0.1.tgz#b929ba5b4b6f7108abf49adaf03309159047c134"
-  integrity sha512-4a2IoekfGUgV/dinAB7Tx5oqA+Pg9I/6x/t8n/yduHmdclP5EdWTN4gPrwOKVECKVn2pV1VxAT8q4toSzwa2Eg==
+"@vercel/fetch-cached-dns@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@vercel/fetch-cached-dns/-/fetch-cached-dns-2.0.2.tgz#975c395cf53f188fa618fad57f27af6b5ffc5bab"
+  integrity sha512-gDqKEV8CeY2YmCdZpP1rn3tFK1L07Vw2+HYkCK8zpRHOVGr/sP8yhBsW+C/yqGVj0i9z/rIvqIHe5emvRvxwgw==
   dependencies:
     "@types/node-fetch" "2.3.2"
-    "@zeit/dns-cached-resolve" "2.1.0"
+    "@zeit/dns-cached-resolve" "2.1.2"
 
 "@vercel/fetch-retry@^5.0.2":
   version "5.0.3"
@@ -119,10 +119,10 @@
     signal-exit "3.0.2"
     strip-ansi "^5.0.0"
 
-"@zeit/dns-cached-resolve@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"
-  integrity sha512-KD2zyRZEBNs9PJ3/ob7zx0CvR4wM0oV4G5s5gFfPwmM74GpFbUN2pAAivP2AXnUrJ14Nkh8NumNKOzOyc4LbFQ==
+"@zeit/dns-cached-resolve@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.2.tgz#2c2e33d682d67f94341c9a06ac0e2a8f14ff035f"
+  integrity sha512-A/5gbBskKPETTBqHwvlaW1Ri2orO62yqoFoXdxna1SQ7A/lXjpWgpJ1wdY3IQEcz5LydpS4sJ8SzI2gFyyLEhg==
   dependencies:
     "@types/async-retry" "1.2.1"
     "@types/lru-cache" "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,7 +91,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@vercel/fetch-cached-dns@2.0.2":
+"@vercel/fetch-cached-dns@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@vercel/fetch-cached-dns/-/fetch-cached-dns-2.0.2.tgz#975c395cf53f188fa618fad57f27af6b5ffc5bab"
   integrity sha512-gDqKEV8CeY2YmCdZpP1rn3tFK1L07Vw2+HYkCK8zpRHOVGr/sP8yhBsW+C/yqGVj0i9z/rIvqIHe5emvRvxwgw==


### PR DESCRIPTION
Bump `@vercel/fetch-cached-dns` to `2.0.2` to ensure it can resolve `localhost`.