### PR TITLE
types: Add optional fetch param

### DIFF
--- a/packages/fetch-cached-dns/index.d.ts
+++ b/packages/fetch-cached-dns/index.d.ts
@@ -1,6 +1,6 @@
-import { Request, RequestInit, Response } from 'node-fetch';
+import NodeFetch, { Request, RequestInit, Response } from 'node-fetch';
 
-export default function createFetch(): (
+export default function createFetch(fetch?: typeof NodeFetch): (
   url: string | Request,
   init?: RequestInit,
 ) => Promise<Response>;


### PR DESCRIPTION
## Changes
- Adds typing for the optional `fetch` param to the generator function of `@vercel/fetch-cached-dns`
  - Source: https://github.com/ofhouse/vercel-fetch/blob/main/packages/fetch-cached-dns/index.js#L10-L13

As described in the Readme of the package, the generator function accepts an optional param fetch:
```js
const fetch = require('@vercel/fetch-cached-dns')(require('node-fetch'));
```

However when translating it to TypeScript, it is not possible to pass a fetch:

```ts
import nodeFetch from 'node-fetch';
import createFetch from '@vercel/fetch-cached-dns';

const fetch = createFetch(createFetch); // Error: Expected 0 arguments, but got 1
```
[TS Playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAOwgEwKYDFUwMYAs4BmUEIcA5EmgLQFZ5kDcAUKJLHNlKgIYwZ34iJcgAEAbqijZUAGwD0tHLirZueVMirIEAZ0ZMm2CLviK8cALwcuvfkoAUnHn0xKAlAzhy5cAKJRiKCYgA)

