### PR TITLE
fix(undici): use native Headers implementation if supported

### DIFF
--- a/packages/fetch-cached-dns/index.js
+++ b/packages/fetch-cached-dns/index.js
@@ -11,7 +11,10 @@ function setup(fetch) {
   if (!fetch) {
     fetch = require('node-fetch');
   }
-  const { Headers } = fetch;
+  const Headers =
+    typeof globalThis.Headers === 'undefined'
+      ? fetch.Headers
+      : globalThis.Headers;
 
   async function fetchCachedDns(url, opts) {
     const parsed = parse(url);

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -41,7 +41,11 @@ function setupVercelFetch(fetch, agentOpts = {}) {
     }
 
     opts.redirect = 'manual';
-    opts.headers = new fetch.Headers(opts.headers);
+    const Headers =
+      typeof globalThis.Headers === 'undefined'
+        ? fetch.Headers
+        : globalThis.Headers;
+    opts.headers = new Headers(opts.headers);
     // Workaround for node-fetch + agentkeepalive bug/issue
     opts.headers.set('host', opts.headers.get('host') || parseUrl(url).host);
 

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -79,7 +79,7 @@ function setupVercelFetch(fetch, agentOpts = {}) {
 
 function setup(fetch, options) {
   if (!fetch) {
-    fetch = require('node-fetch');
+    fetch = globalThis.fetch ?? require('node-fetch');
   }
 
   const fd = fetch.default;

--- a/packages/fetch/readme.md
+++ b/packages/fetch/readme.md
@@ -34,4 +34,4 @@ import * as fetch from 'some-fetch-implementation';
 const fetch = createFetch(fetch);
 ```
 
-If no fetch implementation is supplied, it will attempt to use peerDep `node-fetch`.
+If no fetch implementation is supplied, it will attempt to use native fetch (if available) or peerDep `node-fetch` as fallback.

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ These packages are designed for use with Node.js in order to bring the familiari
 
 ## Getting Started
 
-`@vercel/fetch` bundles all packages inside this monorepo together into a super-powered [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) client. By default, this package will use its peer dependency [node-fetch](https://github.com/node-fetch/node-fetch), but it also supports other fetch implementations.
+`@vercel/fetch` bundles all packages inside this monorepo together into a super-powered [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) client. By default, this package will use native fetch (if available) or its peer dependency [node-fetch](https://github.com/node-fetch/node-fetch) as fallback, but it also supports other fetch implementations.
 
 ```js
 // Basic Usage


### PR DESCRIPTION
Attempt to integrate with nodejs native fetch (undici) cc @Ethan-Arrowood  : https://mobile.twitter.com/ArrowoodTech/status/1492225686718849026