### PR TITLE
fix: handle exception named `AbortError` according to the latest `AbortController` specification

### DIFF
--- a/packages/fetch-retry/index.js
+++ b/packages/fetch-retry/index.js
@@ -65,7 +65,7 @@ function setup(fetch) {
             return res;
           }
         } catch (err) {
-          if (err.type === 'aborted') {
+          if (err.type === 'aborted' || err.name === 'AbortError') {
             return bail(err);
           }
           const clientError = isClientError(err);


### PR DESCRIPTION
This fix would make the different platforms work in the same way by omitting retries.