### PR TITLE
fix: handle the exception from native `AbortController`

### DIFF
--- a/packages/fetch-retry/index.js
+++ b/packages/fetch-retry/index.js
@@ -65,7 +65,7 @@ function setup(fetch) {
             return res;
           }
         } catch (err) {
-          if (err.type === 'aborted') {
+          if (err.type === 'aborted' || err.name === 'AbortError') {
             return bail(err);
           }
           const clientError = isClientError(err);

--- a/packages/fetch-retry/test.js
+++ b/packages/fetch-retry/test.js
@@ -180,7 +180,9 @@ test("don't retry if the request was aborted after timeout", async () => {
 
   const timeoutHandler = setTimeout(() => {
     ponyfilledController.abort();
-    nativeController?.abort();
+    if (nativeController) {
+      nativeController.abort();
+    }
   }, timeout);
 
   const opts1 = {


### PR DESCRIPTION
The PR closes #77.

Currently, `@vercel/fetch-retry` is only compatible with the `abort-controller` package. It will not work with the native `AbortController` or Vercel's Edge Runtime.

@outaTiME had opened PR #77 to solve this. However, it appears that he is no longer actively working on that PR anymore.

The PR cherry-picks the fix from @outaTiME and updates the test case for coverage.

cc @Ethan-Arrowood 
